### PR TITLE
Zarr speedup

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -17,7 +17,8 @@ def main():
 
     # Add input arguments
     my_parser.add_argument(
-        "input_wbs_file",
+        "-i",
+        "--input_file",
         type=str,
         help="Path to a csv or txt file containing a list of waterbody IDs",
     )
@@ -58,25 +59,32 @@ def main():
 
     # Execute the parse_args() method
     args = my_parser.parse_args()
-    input_wbs_file = Path(args.input_wbs_file)
-
-    # Check if the input file exists
-    if not input_wbs_file.exists():
-        print(f"The file {input_wbs_file} does not exist")
+    if not any([args.subset, args.forcings, args.realization]):
+        print("At least one of --subset, --forcings, or --realization must be set.")
         sys.exit()
+    if args.subset:
+        input_file = Path(args.input_file)
 
-    # Validate the file type
-    if input_wbs_file.suffix not in [".csv", ".txt", ""]:
-        print(f"Unsupported file type: {input_wbs_file.suffix}")
-        sys.exit()
+        # Check if the input file exists
+        if not input_file.exists():
+            print(f"The file {input_file} does not exist")
+            sys.exit()
 
-    # Read in the waterbody IDs
-    with input_wbs_file.open("r") as f:
-        waterbody_ids = f.read().splitlines()
+        # Validate the file type
+        if input_file.suffix not in [".csv", ".txt", ""]:
+            print(f"Unsupported file type: {input_file.suffix}")
+            sys.exit()
+
+        # Read in the waterbody IDs
+        with input_file.open("r") as f:
+            waterbody_ids = f.read().splitlines()
     if args.output_name:
         wb_id_for_name = args.output_name
-    else:
+    elif waterbody_ids:
         wb_id_for_name = waterbody_ids[0]
+    else:
+        print("No waterbody input file or output folder provided.")
+        sys.exit()
     paths = file_paths(wb_id_for_name)
     output_folder = paths.subset_dir()
 

--- a/data_processing/create_realization.py
+++ b/data_processing/create_realization.py
@@ -33,6 +33,7 @@ class GlobalRealization:
             dat["time"] = self.time
         if self.routing is not None:
             dat["routing"] = self.routing
+        dat["output_root"] = "/ngen/ngen/data/outputs/ngen"
 
         return json.dumps(dat, sort_keys=False, indent=4)
 
@@ -194,8 +195,11 @@ def parse_cfe_parameters(cfe_noahowp_attributes: pandas.DataFrame) -> typing.Dic
 
 
 def make_catchment_configs(base_dir: Path, catchment_configs: pandas.DataFrame) -> None:
+    cat_config_dir = base_dir / "cat_config"
+    cat_config_dir.mkdir(parents=True, exist_ok=True)
+
     for name, conf in catchment_configs.items():
-        with open(f"{base_dir}/{name}_config.ini", "w") as f:
+        with open(f"{cat_config_dir}/{name}_config.ini", "w") as f:
             for k, v in conf.items():
                 f.write(f"{k}={v}\n")
 
@@ -216,7 +220,7 @@ def create_cfe_realization(
     for key, val in catchment_configs.items():
         # wb_key = f"wb-{key.split('-')[1]}"
         config_name = f"{key}_config.ini"
-        config_path_ini = f"{config_path}/{config_name}"
+        config_path_ini = f"{config_path}/cat_config/{config_name}"
         forcing_file_path = f"{forcing_path}/by_catchment/{key}.csv"
 
         # CFE
@@ -284,19 +288,24 @@ def create_cfe_realization(
         f.write(realization.toJSON())
 
     with open(paths.template_troute_config(), "r") as file:
-        ngen = yaml.safe_load(file)  # Use safe_load for loading
+        troute = yaml.safe_load(file)  # Use safe_load for loading
 
     geo_file_path = f"/ngen/ngen/data/config/{wb_id}_subset.gpkg"
-    network_topology = ngen["network_topology_parameters"]
+    network_topology = troute["network_topology_parameters"]
     supernetwork_params = network_topology["supernetwork_parameters"]
 
     supernetwork_params["geo_file_path"] = geo_file_path
-    ngen["compute_parameters"]["restart_parameters"]["start_datetime"] = time["start_time"]
+    troute["compute_parameters"]["restart_parameters"]["start_datetime"] = time["start_time"]
     # TODO figure out what ngens doing with the timesteps.
-    ngen["compute_parameters"]["forcing_parameters"]["nts"] = time["nts"]
+    troute["compute_parameters"]["forcing_parameters"]["nts"] = time["nts"]
+    time_step_size = int(troute["compute_parameters"]["forcing_parameters"]["dt"])  # seconds
+    number_of_steps = time["nts"]
+    number_of_hourly_steps = number_of_steps * time_step_size / 3600
+    # not setting this will cause troute to output one netcdf file per timestep
+    troute["output_parameters"]["stream_output"]["stream_output_time"] = number_of_hourly_steps
 
     with open(base_dir / "ngen.yaml", "w") as file:
-        yaml.dump(ngen, file)
+        yaml.dump(troute, file)
 
     # copy the awi base config to the config directory
     shutil.copy(paths.data_sources() / "awi_config.ini", base_dir)

--- a/data_processing/file_paths.py
+++ b/data_processing/file_paths.py
@@ -73,3 +73,6 @@ class file_paths:
         Path(self.subset_dir() / "restart").mkdir(parents=True, exist_ok=True)
         Path(self.subset_dir() / "lakeout").mkdir(parents=True, exist_ok=True)
         Path(self.subset_dir() / "outputs").mkdir(parents=True, exist_ok=True)
+        Path(self.subset_dir() / "outputs" / "ngen").mkdir(parents=True, exist_ok=True)
+        Path(self.subset_dir() / "outputs" / "parquet").mkdir(parents=True, exist_ok=True)
+        Path(self.subset_dir() / "outputs" / "troute").mkdir(parents=True, exist_ok=True)

--- a/data_processing/forcings.py
+++ b/data_processing/forcings.py
@@ -108,10 +108,9 @@ def compute_zonal_stats(
 
     catchments = pd.concat(catchments)
 
-    logger.info("Adding APCP_SURFACE to dataset")
     # adding APCP_SURFACE to the dataset, this is a hack and not a real APCP_SURFACE
     merged_data["APCP_surface"] = (merged_data["RAINRATE"] * 3600 * 1000) / 0.998
-    logger.info("Added APCP_SURFACE to dataset")
+
     variables = [
         "LWDOWN",
         "PSFC",
@@ -155,6 +154,21 @@ def compute_zonal_stats(
     for file in output_folder.glob("*.csv"):
         file.unlink()
 
+    final_ds = final_ds.rename_vars(
+        {
+            "LWDOWN": "DLWRF_surface",
+            "PSFC": "PRES_surface",
+            "Q2D": "SPFH_2maboveground",
+            "RAINRATE": "precip_rate",
+            "SWDOWN": "DSWRF_surface",
+            "T2D": "TMP_2maboveground",
+            "U2D": "UGRD_10maboveground",
+            "V2D": "VGRD_10maboveground",
+            "APCP_surface": "APCP_surface",
+        }
+    )
+
+    logger.info("Saving to disk")
     # Save to disk
     delayed_saves = []
     for catchment in final_ds.catchment.values:
@@ -167,7 +181,9 @@ def compute_zonal_stats(
 
     dask.compute(*delayed_saves)
 
-    logger.info(f"Zonal stats computed in {time.time() - timer_start} seconds")
+    logger.info(
+        f"Forcing generation complete!\nZonal stats computed in {time.time() - timer_start} seconds"
+    )
 
 
 def setup_directories(wb_id: str) -> file_paths:

--- a/data_processing/forcings.py
+++ b/data_processing/forcings.py
@@ -64,19 +64,19 @@ def clip_dataset_to_bounds(
 def compute_store(stores: xr.Dataset, cached_nc_path: Path) -> xr.Dataset:
     if file_paths.dev_file().exists():
         stores.to_netcdf(cached_nc_path)
-    data = xr.open_mfdataset(cached_nc_path, parallel=True)
+    data = xr.open_mfdataset(cached_nc_path, parallel=True, engine="h5netcdf")
     return data
 
 
 @numba.njit(parallel=True)
-def compute_weighted_sum(data_array, cell_ids, weights):
-    sum_at_timestep = np.zeros(data_array.shape[0])
+def compute_weighted_mean(data_array, cell_ids, weights):
+    mean_at_timestep = np.zeros(data_array.shape[0])
     for time_step in numba.prange(data_array.shape[0]):
         weighted_total = 0.0
         for i in range(cell_ids.shape[0]):
             weighted_total += data_array[time_step][cell_ids[i]] * weights[i]
-        sum_at_timestep[time_step] = weighted_total
-    return sum_at_timestep
+        mean_at_timestep[time_step] = weighted_total / weights.sum()
+    return mean_at_timestep
 
 
 def get_cell_weights(raster, gdf):
@@ -107,6 +107,7 @@ def compute_zonal_stats(
         catchments = pool.starmap(get_cell_weights, args)
 
     catchments = pd.concat(catchments)
+    print(catchments)
 
     # adding APCP_SURFACE to the dataset, this is a hack and not a real APCP_SURFACE
     merged_data["APCP_surface"] = (merged_data["RAINRATE"] * 3600 * 1000) / 0.998
@@ -126,12 +127,12 @@ def compute_zonal_stats(
     results = []
     for variable in variables:
         variable_data = []
-        raster = merged_data[variable].data.reshape(merged_data[variable].shape[0], -1).compute()
+        raster = merged_data[variable].values.reshape(merged_data[variable].shape[0], -1)
         for catchment in catchments.index.unique():
             cell_ids = catchments.loc[catchment]["cell_id"]
             weights = catchments.loc[catchment]["coverage"]
 
-            mean_at_timesteps = compute_weighted_sum(raster, cell_ids, weights)
+            mean_at_timesteps = compute_weighted_mean(raster, cell_ids, weights)
 
             temp_da = xr.DataArray(
                 mean_at_timesteps,
@@ -196,7 +197,7 @@ def setup_directories(wb_id: str) -> file_paths:
 
 def create_forcings(start_time: str, end_time: str, output_folder_name: str) -> None:
     forcing_paths = setup_directories(output_folder_name)
-    projection = xr.open_dataset(forcing_paths.template_nc(), engine="netcdf4").crs.esri_pe_string
+    projection = xr.open_dataset(forcing_paths.template_nc(), engine="h5netcdf").crs.esri_pe_string
     logger.info("Got projection from grid file")
 
     gdf = load_geodataframe(forcing_paths.geopackage_path(), projection)
@@ -207,10 +208,13 @@ def create_forcings(start_time: str, end_time: str, output_folder_name: str) -> 
     if type(end_time) == datetime:
         end_time = end_time.strftime("%Y-%m-%d %H:%M")
 
+    merged_data = None
     if os.path.exists(forcing_paths.cached_nc_file()):
         logger.info("found cached nc file")
         # open the cached file and check that the time range is correct
-        cached_data = xr.open_mfdataset(forcing_paths.cached_nc_file(), parallel=True)
+        cached_data = xr.open_mfdataset(
+            forcing_paths.cached_nc_file(), parallel=True, engine="h5netcdf"
+        )
         if cached_data.time[0].values <= np.datetime64(start_time) and cached_data.time[
             -1
         ].values >= np.datetime64(end_time):
@@ -222,17 +226,16 @@ def create_forcings(start_time: str, end_time: str, output_folder_name: str) -> 
             os.remove(forcing_paths.cached_nc_file())
             logger.info("Removed cached nc file")
 
-            logger.info("Loading zarr stores, this may take a while.")
-            lazy_store = load_zarr_datasets()
-            logger.info("Got zarr stores")
+    if merged_data is None:
+        logger.info("Loading zarr stores, this may take a while.")
+        lazy_store = load_zarr_datasets()
+        logger.info("Got zarr stores")
 
-            clipped_store = clip_dataset_to_bounds(
-                lazy_store, gdf.total_bounds, start_time, end_time
-            )
-            logger.info("Clipped stores")
+        clipped_store = clip_dataset_to_bounds(lazy_store, gdf.total_bounds, start_time, end_time)
+        logger.info("Clipped stores")
 
-            merged_data = compute_store(clipped_store, forcing_paths.cached_nc_file())
-            logger.info("Computed store")
+        merged_data = compute_store(clipped_store, forcing_paths.cached_nc_file())
+        logger.info("Computed store")
 
     logger.info("Computing zonal stats")
     compute_zonal_stats(gdf, merged_data, forcing_paths.forcings_dir())

--- a/data_processing/forcings.py
+++ b/data_processing/forcings.py
@@ -69,14 +69,14 @@ def compute_store(stores: xr.Dataset, cached_nc_path: Path) -> xr.Dataset:
 
 
 @numba.njit(parallel=True)
-def compute_weighted_mean(data_array, cell_ids, weights):
-    mean_at_timestep = np.zeros(data_array.shape[0])
+def compute_weighted_sum(data_array, cell_ids, weights):
+    sum_at_timestep = np.zeros(data_array.shape[0])
     for time_step in numba.prange(data_array.shape[0]):
         weighted_total = 0.0
         for i in range(cell_ids.shape[0]):
             weighted_total += data_array[time_step][cell_ids[i]] * weights[i]
-        mean_at_timestep[time_step] = weighted_total
-    return mean_at_timestep
+        sum_at_timestep[time_step] = weighted_total
+    return sum_at_timestep
 
 
 def get_cell_weights(raster, gdf):
@@ -131,7 +131,7 @@ def compute_zonal_stats(
             cell_ids = catchments.loc[catchment]["cell_id"]
             weights = catchments.loc[catchment]["coverage"]
 
-            mean_at_timesteps = compute_weighted_mean(raster, cell_ids, weights)
+            mean_at_timesteps = compute_weighted_sum(raster, cell_ids, weights)
 
             temp_da = xr.DataArray(
                 mean_at_timesteps,

--- a/data_processing/forcings.py
+++ b/data_processing/forcings.py
@@ -107,7 +107,6 @@ def compute_zonal_stats(
         catchments = pool.starmap(get_cell_weights, args)
 
     catchments = pd.concat(catchments)
-    print(catchments)
 
     # adding APCP_SURFACE to the dataset, this is a hack and not a real APCP_SURFACE
     merged_data["APCP_surface"] = (merged_data["RAINRATE"] * 3600 * 1000) / 0.998
@@ -219,8 +218,11 @@ def create_forcings(start_time: str, end_time: str, output_folder_name: str) -> 
             -1
         ].values >= np.datetime64(end_time):
             logger.info("Time range is correct")
-            merged_data = cached_data
             logger.info(f"Opened cached nc file: [{forcing_paths.cached_nc_file()}]")
+            merged_data = clip_dataset_to_bounds(
+                cached_data, gdf.total_bounds, start_time, end_time
+            )
+            logger.info("Clipped stores")
         else:
             logger.info("Time range is incorrect")
             os.remove(forcing_paths.cached_nc_file())

--- a/data_processing/forcings.py
+++ b/data_processing/forcings.py
@@ -7,6 +7,9 @@ from typing import Tuple
 from functools import partial, cache
 from datetime import datetime
 
+import numba
+import numpy as np
+import dask
 import geopandas as gpd
 import pandas as pd
 import s3fs
@@ -17,10 +20,12 @@ from data_processing.file_paths import file_paths
 
 logger = logging.getLogger(__name__)
 
+
 @cache
 def open_s3_store(url: str) -> s3fs.S3Map:
     """Open an s3 store from a given url."""
     return s3fs.S3Map(url, s3=s3fs.S3FileSystem(anon=True))
+
 
 @cache
 def load_zarr_datasets() -> xr.Dataset:
@@ -45,125 +50,99 @@ def clip_dataset_to_bounds(
     dataset: xr.Dataset, bounds: Tuple[float, float, float, float], start_time: str, end_time: str
 ) -> xr.Dataset:
     """Clip the dataset to specified geographical bounds."""
-    dataset = dataset.sel(x=slice(bounds[0], bounds[2]), y=slice(bounds[1], bounds[3]), time=slice(start_time, end_time))
+    dataset = dataset.sel(
+        x=slice(bounds[0], bounds[2]),
+        y=slice(bounds[1], bounds[3]),
+        time=slice(start_time, end_time),
+    )
     logger.info("Selected time range and clipped to bounds")
     return dataset
 
 
-def compute_store(stores: xr.Dataset, subset_dir: Path) -> xr.Dataset:
-    merged_data = stores.compute()
+def compute_store(stores: xr.Dataset, cached_nc_path: Path) -> xr.Dataset:
     if file_paths.dev_file().exists():
-        merged_data.to_netcdf(subset_dir)
-    return merged_data
+        stores.to_netcdf(cached_nc_path)
+    data = xr.open_dataset(cached_nc_path, chunks={})
+    return data
 
 
-def compute_and_save(
-    rasters: xr.Dataset,
-    forcings_dir: Path,
-    times: pd.DatetimeIndex,
-    gdf_chunk: gpd.GeoDataFrame,
-    variable: str,
-) -> pd.DataFrame:
-    """
-    Compute and save zonal stats for a given variable on a given chunk of the geodataframe.
-    This function is called in parallel.
-    """
-    raster = rasters[variable]
-    logger.debug(f"Computing {variable} for all times")
-    results = exact_extract(
-        raster, gdf_chunk, ["mean"], include_cols=["divide_id"], output="pandas"
+@numba.njit(parallel=True)
+def compute_weighted_mean(data_array, cell_ids, weights):
+    mean_at_timestep = np.zeros(data_array.shape[0])
+    for time_step in numba.prange(data_array.shape[0]):
+        weighted_total = 0.0
+        for i in range(cell_ids.shape[0]):
+            weighted_total += data_array[time_step][cell_ids[i]] * weights[i]
+        mean_at_timestep[time_step] = weighted_total
+    return mean_at_timestep
+
+
+def get_cell_weights(raster, gdf):
+    one_timestep = raster.isel(time=0)
+    output = exact_extract(
+        one_timestep["LWDOWN"],
+        gdf,
+        ["cell_id", "coverage"],
+        include_cols=["divide_id"],
+        output="pandas",
     )
-
-    results.set_index("divide_id", inplace=True)
-
-    for i in results.index:
-        single_divide = results.loc[i].to_frame()
-        # drop first row if needed
-        if len(single_divide) != len(times):
-            single_divide = single_divide.iloc[1:]
-        divide_id = single_divide.columns[0]
-        single_divide.columns = [variable]
-        # convert row index to timestamp
-        single_divide.index = times
-        if variable == "RAINRATE":
-            single_divide["APCP_surface"] = (single_divide[variable] * 3600 * 1000) / 0.998
-        # write to file
-        single_divide.to_feather(forcings_dir / f"temp/{variable}_{divide_id}.feather")
-
-
-def chunk_gdf(gdf, chunk_size):
-    """Yield successive n-sized chunks from gdf."""
-    for i in range(0, len(gdf), chunk_size):
-        yield gdf.iloc[i : i + chunk_size]
+    return output.set_index("divide_id")
 
 
 def compute_zonal_stats(
-    gdf: gpd.GeoDataFrame, merged_data: xr.Dataset, forcings_dir: Path, chunk_size=None
+    gdf: gpd.GeoDataFrame, merged_data: xr.Dataset, forcings_dir: Path
 ) -> None:
     logger.info("Computing zonal stats in parallel for all timesteps")
     timer_start = time.time()
-    for file in os.listdir(forcings_dir / "temp"):
-        os.remove(forcings_dir / "temp" / file)
+    catchments = get_cell_weights(
+        merged_data, gdf
+    )  # Assuming this returns a DataFrame or similar structure
 
     variables = ["LWDOWN", "PSFC", "Q2D", "RAINRATE", "SWDOWN", "T2D", "U2D", "V2D"]
-    # compute zonal stats in parallel, chunks should be an 8th of total cpu count
-    # computation is done once per chunk per variable aka chunks * variables
 
-    if chunk_size is None:
-        # the - signs invert the // floor division operator to round up instead of down
-        chunk_size = -(len(variables) * len(gdf) // -multiprocessing.cpu_count())
+    results = []
+    for variable in variables:
+        variable_data = []
+        for catchment in catchments.index.unique():
+            cell_ids = catchments.loc[catchment]["cell_id"]
+            weights = catchments.loc[catchment]["coverage"]
 
-        if chunk_size < 1:
-            # division by zero protection
-            chunk_size = 1
+            # Flatten spatial dimensions for weighted mean calculation if necessary
+            raster = merged_data[variable].data.reshape(merged_data[variable].shape[0], -1)
 
-    logger.debug(f"Chunk size: {chunk_size}")
-    logger.debug(f"CPU count: {multiprocessing.cpu_count()}")
-    logger.debug(f"Total divides: {len(gdf)}")
+            mean_at_timesteps = compute_weighted_mean(raster, cell_ids, weights)
 
-    gdf_chunks = list(chunk_gdf(gdf, chunk_size))
+            temp_da = xr.DataArray(
+                mean_at_timesteps,
+                dims=["time"],
+                coords={"time": merged_data["time"].values},
+                name=f"{variable}_{catchment}",
+            )
+            temp_da = temp_da.assign_coords(catchment=catchment)
+            variable_data.append(temp_da)
 
-    with multiprocessing.Pool() as pool:
-        partial_compute_and_save = partial(
-            compute_and_save, merged_data, forcings_dir, merged_data.time.values
-        )
-        args = [(gdf_chunk, variable) for gdf_chunk in gdf_chunks for variable in variables]
-        pool.starmap(partial_compute_and_save, args)
-    catchment_ids = gdf["divide_id"].unique()
+        # Concatenate data arrays for each variable across all catchments
+        concatenated_da = xr.concat(variable_data, dim="catchment")
+        results.append(concatenated_da.to_dataset(name=variable))
 
-    # clear catchment files
-    for file in os.listdir(forcings_dir / "by_catchment"):
-        os.remove(forcings_dir / "by_catchment" / file)
+    # Combine all variables into a single dataset
+    final_ds = xr.merge(results)
 
-    # open and merge the dfs by catchment
-    for cat in catchment_ids:
-        dfs = []
-        for variable in variables:
-            try:
-                df = pd.read_feather(forcings_dir / f"temp/{variable}_{cat}.feather")
-                dfs.append(df)
-            except FileNotFoundError:
-                logger.warning(f"File not found for {variable} and {cat}")
-        if len(dfs) > 0:
-            merged_df = pd.concat(dfs, axis=1)
-            # rename the columns
-            merged_df.columns = [
-                "DLWRF_surface",
-                "PRES_surface",
-                "SPFH_2maboveground",
-                "precip_rate",
-                "APCP_surface",
-                "DSWRF_surface",
-                "TMP_2maboveground",
-                "UGRD_10maboveground",
-                "VGRD_10maboveground",
-            ]
-            merged_df.index.name = "time"
-            merged_df.to_csv(forcings_dir / f"by_catchment/{cat}.csv")
+    output_folder = forcings_dir / "by_catchment"
+    # Clear out any existing files
+    for file in output_folder.glob("*.csv"):
+        file.unlink()
 
-    for file in os.listdir(forcings_dir / "temp"):
-        os.remove(forcings_dir / "temp" / file)
-    os.rmdir(forcings_dir / "temp")
+    # Save to disk
+    delayed_saves = []
+    for catchment in final_ds.catchment.values:
+        catchment_ds = final_ds.sel(catchment=catchment)
+        csv_path = output_folder / f"{catchment}.csv"
+        delayed_save = dask.delayed(catchment_ds.to_dataframe().to_csv(csv_path))
+        delayed_saves.append(delayed_save)
+
+    dask.compute(*delayed_saves)
+
     logger.info(f"Zonal stats computed in {time.time() - timer_start} seconds")
 
 
@@ -197,10 +176,8 @@ def create_forcings(start_time: str, end_time: str, output_folder_name: str) -> 
         clipped_store = clip_dataset_to_bounds(lazy_store, gdf.total_bounds, start_time, end_time)
         logger.info("Clipped stores")
 
-
-        merged_data = clipped_store
         merged_data = compute_store(clipped_store, forcing_paths.cached_nc_file())
-        #logger.info("Computed store")
+        logger.info("Computed store")
     else:
         merged_data = xr.open_dataset(forcing_paths.cached_nc_file())
         logger.info("Opened cached nc file")

--- a/data_processing/subset.py
+++ b/data_processing/subset.py
@@ -117,8 +117,8 @@ def subset(
     subset_parquet(upstream_ids, paths)
     make_geojson(paths)
     move_files_to_config_dir(paths.subset_dir())
-    logger.info(f"Subset complete for {upstream_ids}")
-
+    logger.info(f"Subset complete for {len(upstream_ids)} catchments")
+    logger.debug(f"Subset complete for {upstream_ids} catchments")
     return str(paths.subset_dir())
 
 

--- a/data_sources/ngen-routing-template.yaml
+++ b/data_sources/ngen-routing-template.yaml
@@ -60,10 +60,10 @@ compute_parameters:
         #----------
         qts_subdivisions: 12
         dt: 300 # [sec]
-        qlat_input_folder: ./
+        qlat_input_folder: ./outputs/ngen/
         qlat_file_pattern_filter: "nex-*"
 
-        binary_nexus_file_folder: ./ # this is required if nexus_file_pattern_filter="nex-*"
+        binary_nexus_file_folder: ./outputs/parquet/ # this is required if nexus_file_pattern_filter="nex-*"
         #coastal_boundary_input_file : channel_forcing/schout_1.nc
         nts: 2880 #288 for 1day
         #nts CONFIGURED IN CODE                     : 8640 #288 for 1day
@@ -98,13 +98,13 @@ compute_parameters:
 #--------------------------------------------------------------------------------
 output_parameters:
     #----------
-    test_output: outputs/lcr_flowveldepth.pkl
+    #test_output: outputs/lcr_flowveldepth.pkl
     lite_restart:
         #----------
         lite_restart_output_directory: restart/
     lakeout_output: lakeout/
     stream_output:
-        stream_output_directory: outputs
+        stream_output_directory: outputs/troute/
         stream_output_time: 1 #[hr]
         stream_output_type: ".csv" #please select only between netcdf '.nc' or '.csv' or '.pkl'
         stream_output_internal_frequency: 60 #[min] it should be order of 5 minutes. For instance if you want to output every hour put 60

--- a/map_app/static/js/main.js
+++ b/map_app/static/js/main.js
@@ -38,9 +38,6 @@ async function update_selected() {
     }
 }
 
-
-
-
 async function populate_upstream() {
     console.log('populating upstream selected');
     // drop any key that is not in the wb_id_dict
@@ -266,6 +263,25 @@ async function addLayers() {
     }));
 }
 
+async function preload_zarrs() {
+    original_text = document.getElementById('forcings-button').textContent;
+    document.getElementById('forcings-button').disabled = true;
+    document.getElementById('forcings-button').textContent = "Preloading Zarr Metadata";
+
+    document.getElementById('forcings-loading').style.visibility = "visible";
+    const zarrs = await fetch('/preload_zarrs', {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+    })
+        .then(_ => {
+            document.getElementById('forcings-button').disabled = false;
+            document.getElementById('forcings-loading').style.visibility = "hidden";
+            document.getElementById('forcings-button').textContent = original_text;
+        });
+}
+
+
+
 geometry_urls = {
     '16': 'e8ddee6a8a90484fa7a976458e79c0c3',
     '01': '5f0e81c665314967a1e15e4ae672aaae',
@@ -333,6 +349,11 @@ var wmtsLayer = L.tileLayer(baseUrl +
 addLayers().then(() => {
     console.log('added layers');
     map.on('click', onMapClick);
+});
+
+preload_zarrs().then((zarrs) => {
+    console.log('preloaded zarrs');
+    console.log(zarrs);
 });
 
 

--- a/map_app/views.py
+++ b/map_app/views.py
@@ -17,7 +17,7 @@ import multiprocessing
 from data_processing.gpkg_utils import get_table_crs, blob_to_geometry, blob_to_centroid
 from data_processing.create_realization import create_cfe_wrapper
 from data_processing.file_paths import file_paths
-from data_processing.forcings import create_forcings
+from data_processing.forcings import create_forcings, load_zarr_datasets
 from data_processing.graph_utils import get_from_to_id_pairs, get_upstream_ids
 from data_processing.subset import subset
 
@@ -312,6 +312,11 @@ def get_wbids_from_vpu():
         ),
         200,
     )
+
+@main.route("/preload_zarrs", methods=["GET"])
+def preload_zarrs():
+    load_zarr_datasets()
+    return "success", 200
 
 
 @main.route("/logs", methods=["GET"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ netcdf4
 dask
 black
 isort
+h5netcdf

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ dask
 black
 isort
 h5netcdf
+numba


### PR DESCRIPTION
# Issues Fixed
- #3
- Forcing generation now 2000x faster (ram permitting)
- parallel partitions for ngen run would collide causing multiple threads to write to the same file
- way way way too many generated files mixed in with important files like troute config and realization

# Changes
- zarr headers fetched on flask app launch
- zarr headers cached on first fetch
- downloaded data now always saves locally
- local data is checked to see if the time range is correct, if not delete it and download new data
- forcing weights calculated with exact_extract, then forcings computed with numba
- updated cli to work without needing the file containing wbs
- ngen outputs redirected to subfolders 
- catchment config for cfe moved to subfolder

# Added
- partition generator for use with multiprocessing in NGIAB